### PR TITLE
Add export helm chart CLI command

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,11 @@
     "command-line-args": "^5.1.1",
     "command-line-usage": "^6.1.1",
     "js-yaml": "^4.1.0",
-    "ws": "^7.5.3"
+    "mkdirp": "^1.0.4",
+    "rimraf": "^3.0.2",
+    "slugify": "^1.6.0",
+    "ws": "^7.5.3",
+    "zip-a-folder": "^1.1.0"
   },
   "devDependencies": {
     "@cubos/eslint-config": "^1.0.536820",
@@ -40,7 +44,9 @@
     "@types/jest": "^26.0.24",
     "@types/js-yaml": "^4.0.2",
     "@types/json-schema": "^7.0.8",
+    "@types/mkdirp": "^1.0.2",
     "@types/node": "^16.3.1",
+    "@types/rimraf": "^3.0.1",
     "@types/ws": "^7.4.6",
     "as-typed": "^1.3.0",
     "jest": "^27.0.6",

--- a/src/base/Controller.ts
+++ b/src/base/Controller.ts
@@ -496,19 +496,21 @@ export class Controller {
   }) {
     const targetList = await this.installList(namespace);
 
-    const resources = [
-      ConfigMap.export(
-        {
-          name: this.name,
-          namespace,
-        },
-        {
-          data: {
-            installedResources: JSON.stringify(targetList),
-          },
-        },
-      ),
-    ];
+    const resources = helm
+      ? []
+      : [
+          ConfigMap.export(
+            {
+              name: this.name,
+              namespace,
+            },
+            {
+              data: {
+                installedResources: JSON.stringify(targetList),
+              },
+            },
+          ),
+        ];
 
     if (this.policyRules.length > 0 || this.clusterPolicyRules.length > 0) {
       resources.push(

--- a/src/base/ControllerCli.ts
+++ b/src/base/ControllerCli.ts
@@ -289,11 +289,15 @@ export class ControllerCli {
       );
     }
 
+    if (!process.env.KUBESDK_CHART_IMAGE) {
+      console.warn("⚠️ KUBESDK_CHART_IMAGE was not set. You must set image manually in values.yaml");
+    }
+
     await fs.promises.copyFile(args[0], path.join(helmChartDir, "Chart.yaml"));
     await fs.promises.writeFile(
       path.join(helmChartDir, "values.yaml"),
       jsyaml.dump({
-        image: "",
+        image: process.env.KUBESDK_CHART_IMAGE,
         secrets: resources
           .filter(r => r.kind === "Secret")
           .reduce<any>((acc, cur) => {

--- a/src/base/ControllerCli.ts
+++ b/src/base/ControllerCli.ts
@@ -271,7 +271,7 @@ export class ControllerCli {
       helm: true,
     });
 
-    const helmChartDir = path.join(__dirname, "._helmChartWd");
+    const helmChartDir = path.join(__dirname, "._helmChartWd", parsedChartYaml.name);
 
     // Cleanup and create the directory
     await rimraf(helmChartDir);

--- a/src/base/ControllerCli.ts
+++ b/src/base/ControllerCli.ts
@@ -311,7 +311,7 @@ export class ControllerCli {
       }),
     );
 
-    console.log(await fs.readFile(path.join(helmChartDir, "values.yaml"), "utf8"));
+    console.log("\nvalues.yaml:\n", await fs.readFile(path.join(helmChartDir, "values.yaml"), "utf8"));
 
     await tar(baseHelmChartWorkingDir, `${parsedChartYaml.name}-${parsedChartYaml.version}.tgz`);
     await rimraf(baseHelmChartWorkingDir);

--- a/src/base/ControllerCli.ts
+++ b/src/base/ControllerCli.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "crypto";
-import fs from "fs";
+import { existsSync, promises as fs } from "fs";
 import path from "path";
 import util from "util";
 
@@ -256,11 +256,11 @@ export class ControllerCli {
       return;
     }
 
-    if (!fs.existsSync(args[0])) {
+    if (!existsSync(args[0])) {
       throw new Error(`Chart.yaml not found: ${args[0]}`);
     }
 
-    const parsedChartYaml: any = jsyaml.load(await fs.promises.readFile(args[0], "utf8"));
+    const parsedChartYaml: any = jsyaml.load(await fs.readFile(args[0], "utf8"));
 
     if (!parsedChartYaml || !parsedChartYaml.name || !parsedChartYaml.version) {
       throw new Error(`Invalid Chart.yaml`);
@@ -282,7 +282,7 @@ export class ControllerCli {
     for (const resource of resources) {
       console.log(`${resource.kind} ${resource.metadata.name}`);
 
-      await fs.promises.writeFile(
+      await fs.writeFile(
         path.join(helmChartDir, "templates", `${slugify(`${resource.kind}-${resource.metadata.name}`)}.yaml`),
         // eslint-disable-next-line require-unicode-regexp
         jsyaml.dump(resource).replace(/'(?<rawValue>{{ .+ }})'$/gm, (_, rawValue: string) => rawValue),
@@ -293,8 +293,8 @@ export class ControllerCli {
       console.warn("⚠️ KUBESDK_CHART_IMAGE was not set. You must set image manually in values.yaml");
     }
 
-    await fs.promises.copyFile(args[0], path.join(helmChartDir, "Chart.yaml"));
-    await fs.promises.writeFile(
+    await fs.copyFile(args[0], path.join(helmChartDir, "Chart.yaml"));
+    await fs.writeFile(
       path.join(helmChartDir, "values.yaml"),
       jsyaml.dump({
         image: process.env.KUBESDK_CHART_IMAGE,
@@ -311,7 +311,7 @@ export class ControllerCli {
       }),
     );
 
-    console.log(await fs.promises.readFile(path.join(helmChartDir, "values.yaml"), "utf8"));
+    console.log(await fs.readFile(path.join(helmChartDir, "values.yaml"), "utf8"));
 
     await tar(baseHelmChartWorkingDir, `${parsedChartYaml.name}-${parsedChartYaml.version}.tgz`);
     await rimraf(baseHelmChartWorkingDir);

--- a/src/base/Resource.ts
+++ b/src/base/Resource.ts
@@ -147,6 +147,9 @@ export interface StaticResource<
   apply: {} extends SpecT
     ? (metadata: CreatableMetadata & MetadataT, spec?: SpecT) => Promise<T>
     : (metadata: CreatableMetadata & MetadataT, spec: SpecT) => Promise<T>;
+  export: {} extends SpecT
+    ? (metadata: CreatableMetadata & MetadataT, spec?: SpecT) => any
+    : (metadata: CreatableMetadata & MetadataT, spec: SpecT) => any;
 }
 
 export interface StaticNamespacedResource<
@@ -179,6 +182,9 @@ export interface StaticNamespacedResource<
   apply: {} extends SpecT
     ? (metadata: CreatableMetadata & MetadataT & { namespace: string }, spec?: SpecT) => Promise<T>
     : (metadata: CreatableMetadata & MetadataT & { namespace: string }, spec: SpecT) => Promise<T>;
+  export: {} extends SpecT
+    ? (metadata: CreatableMetadata & MetadataT & { namespace: string }, spec?: SpecT) => any
+    : (metadata: CreatableMetadata & MetadataT & { namespace: string }, spec: SpecT) => any;
 }
 export class Resource<MetadataT, SpecT, StatusT, KindT extends string, ApiVersionT extends string>
   implements IResource<MetadataT, SpecT, StatusT>
@@ -692,6 +698,16 @@ function implementStaticMethods(
 
       return parseRawObject(conn, raw);
     };
+
+  klass.export = (metadata: CreatableMetadata & { namespace?: string }, spec: unknown) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return {
+      apiVersion,
+      kind,
+      metadata,
+      ...(hasInlineSpec ? (spec as any) ?? {} : { spec: spec ?? {} }),
+    };
+  };
 }
 
 export function wrapResource<


### PR DESCRIPTION
Adds the command `chart <path to Chart.yaml>` that creates a `tgz` file of the controller ready for Helm publish.